### PR TITLE
Cast args.port to int

### DIFF
--- a/geofront/server.py
+++ b/geofront/server.py
@@ -1073,7 +1073,7 @@ def main():  # pragma: no cover
         )
     try:
         if args.debug:
-            app.run(args.host, args.port, debug=True)
+            app.run(args.host, int(args.port), debug=True)
         else:
             serve(app, host=args.host, port=args.port, asyncore_use_poll=True,
                   **waitress_options)


### PR DESCRIPTION
`socket.bind(address)` only allows integer port. Port variable with str type could be raised exception when run with debug mode.