### PR TITLE
libcloud's EC2 driver now offers ex_get_metadata_for_node() instead.

### DIFF
--- a/geofront/backends/cloud.py
+++ b/geofront/backends/cloud.py
@@ -150,12 +150,12 @@ class CloudRemoteSet(collections.abc.Mapping):
 @singledispatch
 def supports_metadata(driver: NodeDriver) -> bool:
     """Whether this drive type supports metadata?"""
-    return callable(getattr(driver, 'ex_get_metadata', None))
+    return callable(getattr(driver, 'ex_get_metadata_for_node', None))
 
 
 @singledispatch
 def get_metadata(driver: NodeDriver, node: Node) -> Mapping[str, object]:
-    return driver.ex_get_metadata(node)
+    return driver.ex_get_metadata_for_node(node)
 
 
 @supports_metadata.register(GCENodeDriver)


### PR DESCRIPTION
 * refs #25
 * A quick googling shows that EC2, Rackspace and OpenStack drivers have `ex_get_metadata_for_node()` method while GCE and Azure drivers not.